### PR TITLE
fix name

### DIFF
--- a/Terraform/GCP/k8s/values/minio-sync.yaml
+++ b/Terraform/GCP/k8s/values/minio-sync.yaml
@@ -48,7 +48,7 @@ configuration:
       keys:
         - key: gcs_bucket
           envKey: GCS_BUCKET
-        - key: minio_buket
+        - key: minio_bucket
           envKey: MINIO_BUCKET
 
 serviceAccount:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the configuration for the scheduled MinIO synchronization. The environment variable for the bucket name is now properly aligned with expected naming conventions for reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->